### PR TITLE
Fix overlapped time window message

### DIFF
--- a/src/main/java/com/cmsApp/cms/service/ContentServiceImp.java
+++ b/src/main/java/com/cmsApp/cms/service/ContentServiceImp.java
@@ -41,7 +41,7 @@ public class ContentServiceImp implements ContentService {
             content.addLicenseToContent(license);
             return contentRepository.save(content);
         } else
-            throw new TimeWindowException("Time windows is overlapped.");
+            throw new TimeWindowException("Time window is overlapped.");
     }
 
 

--- a/src/main/java/com/cmsApp/cms/validation/ContentValidation.java
+++ b/src/main/java/com/cmsApp/cms/validation/ContentValidation.java
@@ -25,22 +25,22 @@ public class ContentValidation extends Global {
             // Conflict in startTime
             if ((newLicense.getStartTime() < existedLicense.getStartTime())
                     && (newLicense.getEndTime() > existedLicense.getStartTime())) {
-                throw new TimeWindowException("Time windows is overlapped.");
+                throw new TimeWindowException("Time window is overlapped.");
             }
             // Conflict in the middle
             if ((newLicense.getStartTime() > existedLicense.getStartTime())
                     && (newLicense.getEndTime() < existedLicense.getEndTime())) {
-                throw new TimeWindowException("Time windows is overlapped.");
+                throw new TimeWindowException("Time window is overlapped.");
             }
             // Conflict in the endTime
             if ((newLicense.getStartTime() < existedLicense.getEndTime())
                     && (newLicense.getEndTime() > existedLicense.getEndTime())) {
-                throw new TimeWindowException("Time windows is overlapped.");
+                throw new TimeWindowException("Time window is overlapped.");
             }
             // Conflict in the startTime or endTime
             if (newLicense.getStartTime().equals(existedLicense.getStartTime())
                     || newLicense.getEndTime().equals(existedLicense.getEndTime())) {
-                throw new TimeWindowException("Time windows is overlapped.");
+                throw new TimeWindowException("Time window is overlapped.");
             }
         }
 


### PR DESCRIPTION
## Summary
- fix grammar in time window error messages

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6849cf748b30832389d8637fda1db644