### PR TITLE
Fix spelling in comment

### DIFF
--- a/src/main/java/com/cmsApp/cms/validation/ContentValidation.java
+++ b/src/main/java/com/cmsApp/cms/validation/ContentValidation.java
@@ -20,7 +20,7 @@ public class ContentValidation extends Global {
             return true;
         }
 
-        // Controls if the license to be added conflicts with other licences.
+        // Controls if the license to be added conflicts with other licenses.
         for (License existedLicense : content.getLicensesOfContent()) {
             // Conflict in startTime
             if ((newLicense.getStartTime() < existedLicense.getStartTime())


### PR DESCRIPTION
## Summary
- fix the spelling of "licenses" in ContentValidation

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d019838c83238944f92352d7feb5