### PR TITLE
Fix update license endpoint path

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,6 @@ This repository contains a Spring Boot based backend for a simple content manage
 - `GET /license/all` – list all licenses
 - `GET /license/find/{id}` – get a license by ID
 - `POST /license/add` – create a new license
-- `PUT /license/update{licenseId}` – update a license
+- `PUT /license/update/{licenseId}` – update a license
 - `DELETE /license/delete/{licenseId}` – delete a license
 

--- a/src/main/java/com/cmsApp/cms/controller/LicenseController.java
+++ b/src/main/java/com/cmsApp/cms/controller/LicenseController.java
@@ -40,7 +40,7 @@ public class LicenseController {
     }
 
     //Update a license
-    @PutMapping("/update{licenseId}")
+    @PutMapping("/update/{licenseId}")
     public ResponseEntity<License> updateLicense(@PathVariable Long licenseId, @RequestBody License license) {
         licenseServiceImp.updateLicense(licenseId, license);
         return new ResponseEntity<>(license, HttpStatus.OK);


### PR DESCRIPTION
## Summary
- correct path in `LicenseController` for license updates
- document corrected endpoint in `README`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6849d965fb8883238fa18546d587d5c8