### PR TITLE
Remove unused repository field

### DIFF
--- a/src/main/java/com/cmsApp/cms/validation/LicenseValidation.java
+++ b/src/main/java/com/cmsApp/cms/validation/LicenseValidation.java
@@ -1,24 +1,12 @@
 package com.cmsApp.cms.validation;
 
 import com.cmsApp.cms.model.License;
-import com.cmsApp.cms.repository.LicenseRepository;
 import org.springframework.stereotype.Component;
 
 @Component
 public class LicenseValidation {
 
-    LicenseRepository licenseRepository;
-
     public boolean isLicenseTimeValid(Long startTime, Long endTime) {
         return startTime < endTime;     //if startTime smaller, return true
-    }
-
-    public boolean isLicenseExist(License license) {
-        for (License existedLicense : licenseRepository.findAll()) {
-            if (existedLicense.equals(license)) {
-                return true;
-            }
-        }
-        return false;
     }
 }


### PR DESCRIPTION
## Summary
- clean up `LicenseValidation` by removing an unused repository field and helper method

## Testing
- `./mvnw test -q` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6849da242c8c83239924931134938f84