### PR TITLE
Improve license assignment error handling

### DIFF
--- a/src/main/java/com/cmsApp/cms/service/ContentServiceImp.java
+++ b/src/main/java/com/cmsApp/cms/service/ContentServiceImp.java
@@ -34,14 +34,14 @@ public class ContentServiceImp implements ContentService {
     //Add License to Content
     public Content addLicenseToContent(Long contentId, Long licenseId) throws TimeWindowException {
 
-        Content content = contentRepository.findContentById(contentId);
-        License license = licenseRepository.findLicenseById(licenseId);
+        Content content = contentRepository.findById(contentId)
+                .orElseThrow(() -> new ItemNotFoundException("Content not found with this id."));
+        License license = licenseRepository.findById(licenseId)
+                .orElseThrow(() -> new ItemNotFoundException("License not found with this id."));
 
-        if (contentValidation.isLicenseValidForContent(content, license)) {
-            content.addLicenseToContent(license);
-            return contentRepository.save(content);
-        } else
-            throw new TimeWindowException("Time window is overlapped.");
+        contentValidation.isLicenseValidForContent(content, license);
+        content.addLicenseToContent(license);
+        return contentRepository.save(content);
     }
 
 


### PR DESCRIPTION
## Summary
- fetch content and license by ID using `findById(...).orElseThrow` in `ContentServiceImp`
- rely on validation method for `TimeWindowException` and persist the license when validation succeeds

## Testing
- `./mvnw test -q` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6849e2a741dc83238e85711607e95068