### PR TITLE
Fix grammar in license validation comment

### DIFF
--- a/src/main/java/com/cmsApp/cms/validation/LicenseValidation.java
+++ b/src/main/java/com/cmsApp/cms/validation/LicenseValidation.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 public class LicenseValidation {
 
     public boolean isLicenseTimeValid(Long startTime, Long endTime) {
-        return startTime < endTime;     //if startTime smaller, return true
+        // returns true when startTime is earlier than endTime
+        return startTime < endTime;
     }
 }


### PR DESCRIPTION
## Summary
- fix comment grammar in `LicenseValidation`

## Testing
- `./mvnw test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6849f1bfeb148323a70fbc6dc3aae797