### PR TITLE
Add ItemNotFoundException test for unknown IDs

### DIFF
--- a/src/test/java/com/cmsApp/cms/ContentServiceImpTest.java
+++ b/src/test/java/com/cmsApp/cms/ContentServiceImpTest.java
@@ -93,4 +93,21 @@ public class ContentServiceImpTest {
         assertSame(content, result);
         assertTrue(content.getLicensesOfContent().contains(license));
     }
+
+    @Test
+    void addLicenseWithUnknownIdsThrows() {
+        ContentRepository contentRepository = Mockito.mock(ContentRepository.class);
+        LicenseRepository licenseRepository = Mockito.mock(LicenseRepository.class);
+        ContentValidation validation = Mockito.mock(ContentValidation.class);
+        ContentServiceImp service = new ContentServiceImp(contentRepository, validation, licenseRepository);
+
+        Long contentId = 10L;
+        Long licenseId = 20L;
+
+        Mockito.when(contentRepository.findById(contentId)).thenReturn(Optional.empty());
+        Mockito.when(licenseRepository.findById(licenseId)).thenReturn(Optional.of(new License()));
+
+        assertThrows(ItemNotFoundException.class,
+                () -> service.addLicenseToContent(contentId, licenseId));
+    }
 }


### PR DESCRIPTION
## Summary
- extend ContentServiceImpTest with a new test
- ensure ItemNotFoundException thrown when IDs don't exist

## Testing
- `./mvnw test -q` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6849f69b09ec83239d4631fb48c2faac